### PR TITLE
User List Tweaks

### DIFF
--- a/src/components/leaderboards/CategoryList.vue
+++ b/src/components/leaderboards/CategoryList.vue
@@ -1,20 +1,16 @@
 <script setup lang="ts">
 import { useAsyncState } from '@vueuse/core'
-import { useRouteParams, useRouteQuery } from '@vueuse/router'
+import { useRouteQuery } from '@vueuse/router'
 import { computed, watch } from 'vue'
 import { Categories } from '../../lib/api/Categories'
 import { ProblemDetails } from '../../lib/api/data-contracts'
 import { HttpResponse } from '../../lib/api/http-client'
 import Paginator from '../Paginator.vue'
 
-const idQuery = useRouteParams('id', undefined, {
-	transform(val: string | undefined) {
-		if (typeof val === 'undefined') {
-			throw new Error("id shouldn't be undefined")
-		}
-		return parseInt(val, 10)
-	}
-})
+const props = defineProps<{
+	leaderboardId: number
+}>()
+
 const pageQuery = useRouteQuery('page', '1', { transform: Number })
 const limitQuery = useRouteQuery('resultsPerPage', '25', { transform: Number })
 
@@ -34,7 +30,7 @@ const {
 } = useAsyncState(
 	async () => {
 		const resp = await categories.getCategoriesForLeaderboard({
-			id: idQuery.value,
+			id: props.leaderboardId,
 			limit: limitQuery.value,
 			offset: (pageQuery.value - 1) * (limitQuery.value ?? 0)
 		})
@@ -48,8 +44,7 @@ const {
 	}
 )
 
-watch(limitQuery, () => execute())
-watch(pageQuery, () => execute())
+watch([limitQuery, pageQuery], () => execute())
 </script>
 
 <template>

--- a/src/components/leaderboards/List.vue
+++ b/src/components/leaderboards/List.vue
@@ -64,8 +64,7 @@ function filterChanged() {
 	searchedStatus.value = status.value
 }
 
-watch(limitQuery, () => execute(0, query.value))
-watch(pageQuery, () => execute(0, query.value))
+watch([limitQuery, pageQuery], () => execute(0, query.value))
 </script>
 
 <template>

--- a/src/components/leaderboards/View.vue
+++ b/src/components/leaderboards/View.vue
@@ -154,7 +154,7 @@ async function revealRestore() {
 				</tbody>
 			</table>
 
-			<CategoryList />
+			<CategoryList :leaderboard-id="props.id"/>
 		</div>
 	</div>
 </template>

--- a/src/components/leaderboards/View.vue
+++ b/src/components/leaderboards/View.vue
@@ -1,6 +1,5 @@
 <script setup lang="ts">
 import { useAsyncState } from '@vueuse/core'
-import { useRouteParams } from '@vueuse/router'
 import { computed, ref } from 'vue'
 import { useApi } from '../../composables/useApi'
 import { useAuth } from '../../composables/useAuth'
@@ -10,14 +9,9 @@ import { ProblemDetails } from '../../lib/api/data-contracts'
 import { HttpResponse } from '../../lib/api/http-client'
 import CategoryList from './CategoryList.vue'
 
-const idQuery = useRouteParams('id', undefined, {
-	transform(val: string | undefined) {
-		if (typeof val === 'undefined') {
-			throw new Error("id shouldn't be undefined")
-		}
-		return parseInt(val, 10)
-	}
-})
+const props = defineProps<{
+	id: number
+}>()
 
 const updateError = ref('')
 
@@ -35,7 +29,7 @@ const {
 	isLoading,
 	execute
 } = useAsyncState(async () => {
-	const resp = await leaderboards.getLeaderboard(idQuery.value)
+	const resp = await leaderboards.getLeaderboard(props.id)
 	return resp.data
 }, null)
 
@@ -48,7 +42,7 @@ async function revealDelete() {
 		confirm('Really delete this leaderboard? (This action can be reversed)')
 	) {
 		useApi(
-			() => leaderboards.deleteLeaderboard(idQuery.value, useAuth(token.value)),
+			() => leaderboards.deleteLeaderboard(props.id, useAuth(token.value)),
 			() => execute(),
 			(error) => {
 				updateError.value = 'Failed to delete: ' + error.status
@@ -64,7 +58,7 @@ async function revealRestore() {
 		useApi(
 			() =>
 				leaderboards.updateLeaderboard(
-					idQuery.value,
+					props.id,
 					{
 						status: 'Published'
 					},
@@ -98,14 +92,14 @@ async function revealRestore() {
 			>
 			<div class="action-button-container">
 				<RouterLink
-					:to="{ name: 'categoryCreate', params: { id: idQuery } }"
+					:to="{ name: 'categoryCreate', params: { id: id } }"
 					tabindex="-1"
 				>
 					<button class="action-button">Create Category</button>
 				</RouterLink>
 
 				<RouterLink
-					:to="{ name: 'leaderboardEdit', params: { id: idQuery } }"
+					:to="{ name: 'leaderboardEdit', params: { id: id } }"
 					tabindex="-1"
 				>
 					<button class="action-button">Edit</button>

--- a/src/components/leaderboards/View.vue
+++ b/src/components/leaderboards/View.vue
@@ -154,7 +154,7 @@ async function revealRestore() {
 				</tbody>
 			</table>
 
-			<CategoryList :leaderboard-id="props.id"/>
+			<CategoryList :leaderboard-id="props.id" />
 		</div>
 	</div>
 </template>

--- a/src/components/leaderboards/View.vue
+++ b/src/components/leaderboards/View.vue
@@ -99,7 +99,7 @@ async function revealRestore() {
 				</RouterLink>
 
 				<RouterLink
-					:to="{ name: 'leaderboardEdit', params: { id: id } }"
+					:to="{ name: 'leaderboardEdit', params: { id } }"
 					tabindex="-1"
 				>
 					<button class="action-button">Edit</button>

--- a/src/components/leaderboards/View.vue
+++ b/src/components/leaderboards/View.vue
@@ -92,7 +92,7 @@ async function revealRestore() {
 			>
 			<div class="action-button-container">
 				<RouterLink
-					:to="{ name: 'categoryCreate', params: { id: id } }"
+					:to="{ name: 'categoryCreate', params: { id } }"
 					tabindex="-1"
 				>
 					<button class="action-button">Create Category</button>

--- a/src/components/users/List.vue
+++ b/src/components/users/List.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { useAsyncState } from '@vueuse/core'
 import { useRouteQuery } from '@vueuse/router'
-import { ref, Ref, watch } from 'vue'
+import { watch } from 'vue'
 import { useAuth } from '../../composables/useAuth'
 import { useSessionToken } from '../../composables/useSessionToken'
 import { UserRole } from '../../lib/api/data-contracts'

--- a/src/components/users/List.vue
+++ b/src/components/users/List.vue
@@ -105,7 +105,7 @@ watch(rolesQuery, () => {
 				v-model:limit="limitQuery"
 				v-model:page="pageQuery"
 			/>
-			<div v-if="users.total === 0">
+			<div v-if="users.data.length === 0">
 				No users found with the applied filters.
 			</div>
 			<ul v-else>

--- a/src/components/users/List.vue
+++ b/src/components/users/List.vue
@@ -18,9 +18,13 @@ const allRoles: UserRole[] = [
 	'Registered'
 ]
 
-const rolesQuery = useRouteQuery<UserRole[]>('role', ['Administrator', 'Confirmed'], {
-	transform: (roles) => roles.filter(role => allRoles.includes(role))
-})
+const rolesQuery = useRouteQuery<UserRole[]>(
+	'role',
+	['Administrator', 'Confirmed'],
+	{
+		transform: (roles) => roles.filter((role) => allRoles.includes(role))
+	}
+)
 
 const userClient = new Users({
 	baseUrl: import.meta.env.VITE_BACKEND_URL
@@ -40,32 +44,29 @@ const {
 	error,
 	isLoading,
 	execute
-} = useAsyncState(
-	async () => {
-		// Not specifying any roles causes it to default to Admin + Confirmed, which is
-		// unintuitive. Simply don't fetch any data instead.
-		// - Ted W
+} = useAsyncState(async () => {
+	// Not specifying any roles causes it to default to Admin + Confirmed, which is
+	// unintuitive. Simply don't fetch any data instead.
+	// - Ted W
 
-		if (rolesQuery.value.length === 0) {
-			return emptyData
-		}
+	if (rolesQuery.value.length === 0) {
+		return emptyData
+	}
 
-		const resp = await userClient.listUsers(
-			{
-				// @ts-ignore The query param accepts a comma-separated list of roles,
-				// which is something the generated contract can't feasibly make types
-				// for - zysim
-				role: rolesQuery.value.join(','),
-				limit: limitQuery.value,
-				offset: (pageQuery.value - 1) * (limitQuery.value ?? 0)
-			},
-			useAuth(token.value)
-		)
+	const resp = await userClient.listUsers(
+		{
+			// @ts-ignore The query param accepts a comma-separated list of roles,
+			// which is something the generated contract can't feasibly make types
+			// for - zysim
+			role: rolesQuery.value.join(','),
+			limit: limitQuery.value,
+			offset: (pageQuery.value - 1) * (limitQuery.value ?? 0)
+		},
+		useAuth(token.value)
+	)
 
-		return resp.data
-	},
-	emptyData
-)
+	return resp.data
+}, emptyData)
 
 watch([pageQuery, limitQuery], () => execute())
 
@@ -84,7 +85,13 @@ watch(rolesQuery, () => {
 		<h1>Users</h1>
 		<div class="role-change-container">
 			<label class="label" for="roles">Filter roles:</label>
-			<select id="roles" v-model="rolesQuery" name="role" class="input" multiple>
+			<select
+				id="roles"
+				v-model="rolesQuery"
+				name="role"
+				class="input"
+				multiple
+			>
 				<option value="Administrator">Admin</option>
 				<option value="Registered">Registered</option>
 				<option value="Confirmed">Confirmed</option>

--- a/src/main.ts
+++ b/src/main.ts
@@ -48,6 +48,9 @@ const router = createRouter({
 			path: '/leaderboard/:id(\\d+)',
 			name: 'leaderboardView',
 			component: LeaderboardView,
+			props: (route) => ({
+				id: Number.parseInt(route.params.id as string, 10),
+			}),
 		},
 		{
 			path: '/leaderboard/:id(\\d+)/edit',


### PR DESCRIPTION
* Make the router handle route parameters wherever possible, minimizing boilerplate code and maximizing consistency.
* Combine watchers wherever possible.
* Use query params to store the roles directly. This works fine as long as you sanitize the data using `transform`.
* Don't fetch any data if no roles are selected. (See code comments for why this is desirable.)